### PR TITLE
Fix VS 2022 shift conversion warning

### DIFF
--- a/include/alpaca/detail/variable_length_encoding.h
+++ b/include/alpaca/detail/variable_length_encoding.h
@@ -9,15 +9,15 @@ namespace alpaca {
 namespace detail {
 
 template <typename T> bool CHECK_BIT(T &value, uint8_t pos) {
-  return ((value) & (1 << (pos)));
+  return ((value) & (T{1} << (pos)));
 }
 
 template <typename T> void SET_BIT(T &value, uint8_t pos) {
-  value = value | 1 << pos;
+  value = value | T{1} << pos;
 }
 
 template <typename T> void RESET_BIT(T &value, uint8_t pos) {
-  value = value & ~(1 << pos);
+  value = value & ~(T{1} << pos);
 }
 
 template <typename int_t, typename Container>


### PR DESCRIPTION
Original warning message: variable_length_encoding.h(11,23): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?) VS 2022 17.3.4