### PR TITLE
Add C++20 consteval version computation if available

### DIFF
--- a/include/alpaca/detail/struct_nth_field.h
+++ b/include/alpaca/detail/struct_nth_field.h
@@ -8,7 +8,7 @@ namespace detail {
 
 template <std::size_t index, typename type,
           std::size_t arity = aggregate_arity<std::remove_cv_t<type>>::size()>
-constexpr decltype(auto) get(type &value) noexcept {
+constexpr decltype(auto) get(type &&value) noexcept {
 
   if constexpr (arity == 1) {
     auto &[p1] = value;

--- a/include/alpaca/detail/to_bytes.h
+++ b/include/alpaca/detail/to_bytes.h
@@ -44,6 +44,23 @@ to_bytes(T &bytes, std::size_t &byte_index, const U &original_value) {
   copy_bytes_in_range(value, bytes, byte_index);
 }
 
+#if __cpp_constexpr_dynamic_alloc
+template <options O, typename U>
+constexpr void to_bytes_consteval(std::vector<uint8_t> &bytes, std::size_t &byte_index,
+                        const U &original_value) {
+  U value = original_value;
+  if (detail::little_endian<O>()) {
+    for (std::size_t i = 0; i < sizeof(U); i++, byte_index++, value >>= 8) {
+      bytes.push_back(static_cast<uint8_t>(value));
+    }
+  } else {
+    for (std::size_t i = 0; i < sizeof(U); i++, byte_index++, value <<= 8) {
+      bytes.push_back(static_cast<uint8_t>(value >> (8 * (sizeof(U) - 1))));
+    }
+  }
+}
+#endif
+
 // encode as variable-length
 template <options O, typename T, typename U>
 typename std::enable_if<

--- a/include/alpaca/detail/type_info.h
+++ b/include/alpaca/detail/type_info.h
@@ -268,6 +268,100 @@ type_info(
     std::unordered_map<std::string_view, std::size_t> &struct_visitor_map);
 #endif
 
+
+struct ct_struct_map_entry {
+  std::string name;
+  std::size_t val;
+};
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, bool>, void>::
+    type type_info(std::vector<uint8_t> &typeids,
+                             std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::bool_>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, char>, void>::type
+ type_info(std::vector<uint8_t> &typeids,
+                   std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::char_>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, uint8_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::uint8>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, uint16_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::uint16>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, uint32_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::uint32>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, uint64_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::uint64>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, int8_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::int8>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, int16_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::int16>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, int32_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::int32>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, int64_t>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::int64>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, float>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::float32>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_same_v<T, double>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::float64>());
+}
+
+template <typename T>
+constexpr typename std::enable_if<std::is_enum_v<T>, void>::type
+type_info(std::vector<uint8_t> &typeids, std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::enum_class>());
+}
+
+template <typename T,
+          std::size_t N = detail::aggregate_arity<std::remove_cv_t<T>>::size()>
+constexpr
+    typename std::enable_if<std::is_aggregate_v<T> && !is_array_type<T>::value,
+                            void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map);
+
 } // namespace detail
 
 } // namespace alpaca

--- a/include/alpaca/detail/types/array.h
+++ b/include/alpaca/detail/types/array.h
@@ -19,6 +19,16 @@ typename std::enable_if<is_array_type<T>::value, void>::type type_info(
   type_info<value_type>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr typename std::enable_if<is_array_type<T>::value, void>::type
+type_info(std::vector<uint8_t> &typeids,
+          std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::array>());
+  typeids.push_back(std::tuple_size_v<T>);
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/deque.h
+++ b/include/alpaca/detail/types/deque.h
@@ -19,6 +19,16 @@ type_info(
   type_info<value_type>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::deque>::value, void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::deque>());
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/duration.h
+++ b/include/alpaca/detail/types/duration.h
@@ -23,6 +23,19 @@ type_info(
   type_info<rep>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::chrono::duration>::value,
+                            void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::chrono_duration>());
+
+  // save the rep type of duration
+  using rep = typename T::rep;
+  type_info<rep>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/list.h
+++ b/include/alpaca/detail/types/list.h
@@ -19,6 +19,16 @@ type_info(
   type_info<value_type>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::list>::value, void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::list>());
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/map.h
+++ b/include/alpaca/detail/types/map.h
@@ -27,6 +27,18 @@ type_info(
   using mapped_type = typename T::mapped_type;
   type_info<mapped_type>(typeids, struct_visitor_map);
 }
+
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::map>::value, void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::map>());
+  using key_type = typename T::key_type;
+  type_info<key_type>(typeids, struct_visitor_map);
+  using mapped_type = typename T::mapped_type;
+  type_info<mapped_type>(typeids, struct_visitor_map);
+}
 #endif
 
 #ifndef ALPACA_EXCLUDE_SUPPORT_STD_UNORDERED_MAP
@@ -36,6 +48,19 @@ typename std::enable_if<is_specialization<T, std::unordered_map>::value,
 type_info(
     std::vector<uint8_t> &typeids,
     std::unordered_map<std::string_view, std::size_t> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::unordered_map>());
+  using key_type = typename T::key_type;
+  type_info<key_type>(typeids, struct_visitor_map);
+  using mapped_type = typename T::mapped_type;
+  type_info<mapped_type>(typeids, struct_visitor_map);
+}
+
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::unordered_map>::value,
+                            void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
   typeids.push_back(to_byte<field_type::unordered_map>());
   using key_type = typename T::key_type;
   type_info<key_type>(typeids, struct_visitor_map);

--- a/include/alpaca/detail/types/optional.h
+++ b/include/alpaca/detail/types/optional.h
@@ -19,6 +19,16 @@ type_info(
   type_info<value_type>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr typename std::enable_if<is_specialization<T, std::optional>::value,
+                                  void>::type
+type_info(std::vector<uint8_t> &typeids,
+          std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::optional>());
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/pair.h
+++ b/include/alpaca/detail/types/pair.h
@@ -23,6 +23,20 @@ type_info(
   type_info<second_type>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::pair>::value, void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::pair>());
+
+  using first_type = typename T::first_type;
+  type_info<first_type>(typeids, struct_visitor_map);
+
+  using second_type = typename T::second_type;
+  type_info<second_type>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/set.h
+++ b/include/alpaca/detail/types/set.h
@@ -28,6 +28,16 @@ type_info(
   using value_type = typename T::value_type;
   type_info<value_type>(typeids, struct_visitor_map);
 }
+
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::set>::value, void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::set>());
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
 #endif
 
 #ifndef ALPACA_EXCLUDE_SUPPORT_STD_UNORDERED_SET
@@ -37,6 +47,17 @@ typename std::enable_if<is_specialization<T, std::unordered_set>::value,
 type_info(
     std::vector<uint8_t> &typeids,
     std::unordered_map<std::string_view, std::size_t> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::unordered_set>());
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
+
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::unordered_set>::value,
+                            void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &struct_visitor_map) {
   typeids.push_back(to_byte<field_type::unordered_set>());
   using value_type = typename T::value_type;
   type_info<value_type>(typeids, struct_visitor_map);

--- a/include/alpaca/detail/types/string.h
+++ b/include/alpaca/detail/types/string.h
@@ -19,6 +19,15 @@ type_info(std::vector<uint8_t> &typeids,
   typeids.push_back(to_byte<field_type::string>());
 }
 
+template <typename T>
+constexpr
+    typename std::enable_if<is_specialization<T, std::basic_string>::value,
+                            void>::type
+    type_info(std::vector<uint8_t> &typeids,
+              std::vector<ct_struct_map_entry> &) {
+  typeids.push_back(to_byte<field_type::string>());
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/unique_ptr.h
+++ b/include/alpaca/detail/types/unique_ptr.h
@@ -21,6 +21,16 @@ type_info(
   type_info<element_type>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr typename std::enable_if<is_specialization<T, std::unique_ptr>::value,
+                                  void>::type
+type_info(std::vector<uint8_t> &typeids,
+          std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::unique_ptr>());
+  using element_type = typename T::element_type;
+  type_info<element_type>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 

--- a/include/alpaca/detail/types/variant.h
+++ b/include/alpaca/detail/types/variant.h
@@ -25,11 +25,35 @@ void type_info_variant_helper(
   }
 }
 
+template <typename T, std::size_t N, std::size_t I>
+constexpr void
+type_info_variant_helper(std::vector<uint8_t> &typeids,
+                         std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  if constexpr (I < N) {
+
+    // save current type
+    type_info<std::variant_alternative_t<I, T>>(typeids, struct_visitor_map);
+
+    // go to next type
+    type_info_variant_helper<T, N, I + 1>(typeids, struct_visitor_map);
+  }
+}
+
 template <typename T>
 typename std::enable_if<is_specialization<T, std::variant>::value, void>::type
 type_info(
     std::vector<uint8_t> &typeids,
     std::unordered_map<std::string_view, std::size_t> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::variant>());
+  constexpr auto variant_size = std::variant_size_v<T>;
+  type_info_variant_helper<T, variant_size, 0>(typeids, struct_visitor_map);
+}
+
+template <typename T>
+constexpr typename std::enable_if<is_specialization<T, std::variant>::value,
+                                  void>::type
+type_info(std::vector<uint8_t> &typeids,
+          std::vector<ct_struct_map_entry> &struct_visitor_map) {
   typeids.push_back(to_byte<field_type::variant>());
   constexpr auto variant_size = std::variant_size_v<T>;
   type_info_variant_helper<T, variant_size, 0>(typeids, struct_visitor_map);

--- a/include/alpaca/detail/types/vector.h
+++ b/include/alpaca/detail/types/vector.h
@@ -19,6 +19,16 @@ type_info(
   type_info<value_type>(typeids, struct_visitor_map);
 }
 
+template <typename T>
+constexpr typename std::enable_if<is_specialization<T, std::vector>::value,
+                                  void>::type
+type_info(std::vector<uint8_t> &typeids,
+          std::vector<ct_struct_map_entry> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::vector>());
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
+
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes, std::size_t &byte_index);
 


### PR DESCRIPTION
This allows compile-time calculation of versions, eg
```
    uint32_t version = detail::version_helper<T, N>();
00007FF7E8B8811A C7 44 24 24 62 4E 9C 7B mov         dword ptr [rsp+24h],7B9C4E62h  
```