### PR TITLE
Fail at compile time instead of link time

### DIFF
--- a/include/alpaca/alpaca.h
+++ b/include/alpaca/alpaca.h
@@ -118,11 +118,6 @@ to_bytes(T &bytes, std::size_t &byte_index, const U &input) {
                    T, 0>(input, bytes, byte_index);
 }
 
-template <options O, typename T, typename U>
-typename std::enable_if<!std::is_aggregate_v<U> && std::is_class_v<U>,
-                        void>::type
-to_bytes(T &bytes, std::size_t &byte_index, const U &input);
-
 template <options O, typename T, typename Container>
 void to_bytes_router(const T &input, Container &bytes,
                      std::size_t &byte_index) {


### PR DESCRIPTION
Remove the forward-declared `alpaca::details::to_bytes` for non-aggregate types, since each supported type will have it's specialization included from the many `alpaca/details/*` headers, 
it is redundant for defined types.

It is also tricking the compiler into thinking the function exist for every non-aggregate type, which leads to no compile-time error, but a linker error at the end.

Removing it will provide faster feedback to developpers and a more detailed error message.
Reference : https://github.com/p-ranav/alpaca/issues/25