### PR TITLE
Support for std::bitset

### DIFF
--- a/include/alpaca/alpaca.h
+++ b/include/alpaca/alpaca.h
@@ -143,6 +143,7 @@ void serialize_helper(const T &s, Container &bytes, std::size_t &byte_index) {
   }
 }
 
+#ifndef ALPACA_EXCLUDE_SUPPORT_STD_BITSET
 // version for bitset
 template <options O, typename T, typename U>
 typename std::enable_if<is_bitset<U>::value, void>::type
@@ -155,6 +156,7 @@ void to_bytes_router(const std::bitset<N> &input, Container &bytes,
                      std::size_t &byte_index) {
   to_bytes<O>(bytes, byte_index, input);
 }
+#endif
 
 } // namespace detail
 

--- a/include/alpaca/alpaca.h
+++ b/include/alpaca/alpaca.h
@@ -143,6 +143,19 @@ void serialize_helper(const T &s, Container &bytes, std::size_t &byte_index) {
   }
 }
 
+// version for bitset
+template <options O, typename T, typename U>
+typename std::enable_if<is_bitset<U>::value, void>::type
+to_bytes(T &bytes, std::size_t &byte_index, const U &input) {
+  detail::to_bytes_router(input, bytes, byte_index);
+}
+
+template <options O, std::size_t N, typename Container>
+void to_bytes_router(const std::bitset<N> &input, Container &bytes,
+                     std::size_t &byte_index) {
+  to_bytes<O>(bytes, byte_index, input);
+}
+
 } // namespace detail
 
 template <typename T,

--- a/include/alpaca/alpaca.h
+++ b/include/alpaca/alpaca.h
@@ -10,6 +10,7 @@
 #include <alpaca/detail/to_bytes.h>
 #include <alpaca/detail/type_info.h>
 #include <alpaca/detail/types/array.h>
+#include <alpaca/detail/types/bitset.h>
 #include <alpaca/detail/types/deque.h>
 #include <alpaca/detail/types/duration.h>
 #include <alpaca/detail/types/filesystem_path.h>

--- a/include/alpaca/detail/field_type.h
+++ b/include/alpaca/detail/field_type.h
@@ -35,7 +35,8 @@ enum class field_type : uint8_t {
   chrono_duration,
   list,
   deque,
-  filesystem_path
+  filesystem_path,
+  bitset
 };
 
 template <field_type value> constexpr uint8_t to_byte() {

--- a/include/alpaca/detail/is_bitset.h
+++ b/include/alpaca/detail/is_bitset.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <bitset>
 #include <type_traits>
 
 namespace alpaca {

--- a/include/alpaca/detail/is_bitset.h
+++ b/include/alpaca/detail/is_bitset.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <type_traits>
+
+namespace alpaca {
+
+namespace detail {
+
+// check if T is instantiation of Bitset
+template <typename T>
+struct is_bitset : std::false_type {};
+
+template <std::size_t N>
+struct is_bitset<std::bitset<N>> : std::true_type {};
+
+} // namespace detail
+
+} // namespace alpaca

--- a/include/alpaca/detail/is_bitset.h
+++ b/include/alpaca/detail/is_bitset.h
@@ -1,4 +1,5 @@
 #pragma once
+#ifndef ALPACA_EXCLUDE_SUPPORT_STD_BITSET
 #include <bitset>
 #include <type_traits>
 
@@ -16,3 +17,5 @@ struct is_bitset<std::bitset<N>> : std::true_type {};
 } // namespace detail
 
 } // namespace alpaca
+
+#endif // ALPACA_EXCLUDE_SUPPORT_STD_BITSET

--- a/include/alpaca/detail/type_info.h
+++ b/include/alpaca/detail/type_info.h
@@ -1,9 +1,14 @@
 #pragma once
 #include <alpaca/detail/field_type.h>
+#include <alpaca/detail/is_bitset.h>
 #include <alpaca/detail/is_specialization.h>
 
 #ifndef ALPACA_EXCLUDE_SUPPORT_STD_ARRAY
 #include <array>
+#endif
+
+#ifndef ALPACA_EXCLUDE_SUPPORT_STD_BITSET
+#include <bitset>
 #endif
 
 #ifndef ALPACA_EXCLUDE_SUPPORT_STD_FILESYSTEM_PATH
@@ -169,6 +174,15 @@ type_info(
 // array types
 template <typename T>
 typename std::enable_if<is_array_type<T>::value, void>::type type_info(
+    std::vector<uint8_t> &typeids,
+    std::unordered_map<std::string_view, std::size_t> &struct_visitor_map);
+#endif
+
+#ifndef ALPACA_EXCLUDE_SUPPORT_STD_BITSET
+// std::bitset type
+template <typename T>
+typename std::enable_if<is_bitset<T>::value, void>::type
+type_info(
     std::vector<uint8_t> &typeids,
     std::unordered_map<std::string_view, std::size_t> &struct_visitor_map);
 #endif

--- a/include/alpaca/detail/types/bitset.h
+++ b/include/alpaca/detail/types/bitset.h
@@ -1,0 +1,119 @@
+#pragma once
+#ifndef ALPACA_EXCLUDE_SUPPORT_STD_BITSET
+#include <alpaca/detail/to_bytes.h>
+#include <alpaca/detail/type_info.h>
+#include <system_error>
+#include <vector>
+
+namespace alpaca {
+
+namespace detail {
+
+template <typename T>
+typename std::enable_if<is_bitset<T>::value, void>::type
+type_info(
+    std::vector<uint8_t> &typeids,
+    std::unordered_map<std::string_view, std::size_t> &struct_visitor_map) {
+  typeids.push_back(to_byte<field_type::bitset>());
+  using value_type = typename T::value_type;
+  type_info<value_type>(typeids, struct_visitor_map);
+}
+
+template <options O, std::size_t N, typename Container>
+void to_bytes_router(const std::bitset<N> &input, Container &bytes, std::size_t &byte_index);
+
+template <options O, std::size_t N, typename Container>
+void to_bytes_from_bitset_type(const std::bitset<N> &input, Container &bytes,
+                               std::size_t &byte_index) {
+  // save bitset size
+  to_bytes_router<O, std::size_t>(input.size(), bytes, byte_index);
+
+  // serialize the bitset itself into (bits / 8) bytes
+  int num_bytes = input.size() / 8;
+  for (int i=0; i < num_bytes; ++i) {
+    uint8_t byte = 0;
+    for (int bit = 0; bit < 8; ++bit) {
+      int bit_index = byte * 8 + bit;
+      if (bit_index >= input.size()) break;
+      if (input[bit_index]) byte |= (1 << bit);
+    }
+    bytes[byte_index++] = byte;
+  }
+}
+
+template <options O, typename Container, std::size_t N>
+void to_bytes(Container &bytes, std::size_t &byte_index,
+              const std::bitset<N> &input) {
+  to_bytes_from_bitset_type<O>(input, bytes, byte_index);
+}
+
+template <options O, typename T, typename Container>
+void from_bytes_router(T &output, Container &bytes, std::size_t &byte_index,
+                       std::size_t &end_index, std::error_code &error_code);
+
+template <options O, std::size_t N, typename Container>
+bool from_bytes_to_bitset(std::bitset<N> &value, Container &bytes,
+                          std::size_t &current_index, std::size_t &end_index,
+                          std::error_code &error_code) {
+
+  if (current_index >= end_index) {
+    // end of input
+    // return true for forward compatibility
+    return true;
+  }
+
+  // current byte is the size of the vector
+  std::size_t size = 0;
+  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+                                     error_code);
+
+  if (size != N) {
+    // the bitset we received is not the same size as the bitset we were given
+    error_code = std::make_error_code(std::errc::invalid_argument);
+
+    // stop here
+    return false;
+  }
+
+  // we encode the number of bits as the size, but when we actually serialize
+  // them we pack them, so we need to only deserialize size/8 bytes.
+  std::size_t num_serialized_bytes = size / 8;
+
+  if (num_serialized_bytes > end_index - current_index) {
+    // size is greater than the number of bytes remaining
+    error_code = std::make_error_code(std::errc::value_too_large);
+
+    // stop here
+    return false;
+  }
+
+  // reset the value to 0
+  value.reset();
+
+  // read `size` bits and save to value
+  for (std::size_t byte_index = 0; byte_index < num_serialized_bytes; ++byte_index) {
+    // get the byte at byte index
+    uint8_t byte = bytes[byte_index];
+    // loop over the bits
+    for (int i=0; i<8; ++i) {
+      int bit_index = byte_index * 8 + i;
+      if (bit_index > size) break;
+      value[bit_index] = static_cast<bool>(byte & (1 << i));
+    }
+  }
+
+  return true;
+}
+
+template <options O, std::size_t N, typename Container>
+bool from_bytes(std::bitset<N> &output, Container &bytes,
+                std::size_t &byte_index, std::size_t &end_index,
+                std::error_code &error_code) {
+  return from_bytes_to_bitset<O>(output, bytes, byte_index, end_index,
+                                 error_code);
+}
+
+} // namespace detail
+
+} // namespace alpaca
+#endif


### PR DESCRIPTION
Added support for (de-)serialization of `std::bitset` using alpaca.

Related to #21 (since `std::bitfield` provides some of the same use case as struct bitfields).

Example showing bitfield serialization and deserialization works:
![CleanShot 2024-01-10 at 10 16 34](https://github.com/p-ranav/alpaca/assets/213467/b21b2701-0997-43f1-bcbf-5aa40b4b87cd)


Test code:

```c++
    fmt::print("Starting bitfield serialization example!\n");
    //! [bitfield serialization example]
    struct MyBits {
      std::vector<bool> bits; // testing to see if std::vector<bool> space-efficient bitfield
                              // serialization works
      std::bitset<4> bitset;  // testing to see if std::bitset space-efficient bitfield
                              // serialization works
    };
    std::error_code ec;
    // here we try to make 4 bits followed by 4 bits
    MyBits object{{true, false, true, false}, 0b1010};
    fmt::print("object.bits:   {}\n", object.bits);
    fmt::print("object.bitset: {}\n", object.bitset);
    std::vector<uint8_t> buffer;
    auto bytes_written = alpaca::serialize<alpaca::options::none>(object, buffer);
    fmt::print("Serialized {}B to std::vector\n", bytes_written);
    fmt::print("Serialized buffer: {::x}\n", buffer);
    auto new_object = alpaca::deserialize<alpaca::options::none, MyBits>(buffer, ec);
    if (!ec && new_object.bits == object.bits && new_object.bitset == object.bitset) {
      fmt::print("Deserialized successfully!\n");
      fmt::print("\tbits:   {}\n"
                 "\tbitset: {}\n",
                  new_object.bits, new_object.bitset);
    } else {
      fmt::print("Deserialization failed: {}\n", ec.message());
      fmt::print("\tbits:   {}\n"
                 "\tbitset: {}\n",
                  new_object.bits, new_object.bitset);
    }
    //! [bitfield serialization example]
```