### PR TITLE
fix(string): fix deserialization of string with default value

### DIFF
--- a/include/alpaca/detail/types/string.h
+++ b/include/alpaca/detail/types/string.h
@@ -38,7 +38,10 @@ typename std::enable_if<!std::is_same_v<Container, std::ifstream>, bool>::type
 from_bytes(std::basic_string<CharType> &value, Container &bytes,
            std::size_t &current_index, std::size_t &end_index,
            std::error_code &error_code) {
-
+  // clear out the value - this ensures that value will be only what is read
+  // from the stream, and not any previous data that may have been set during
+  // the construction of the containing object T().
+  value.clear();
   if (current_index >= end_index) {
     // end of input
     // return true for forward compatibility
@@ -75,7 +78,10 @@ typename std::enable_if<std::is_same_v<Container, std::ifstream>, bool>::type
 from_bytes(std::basic_string<CharType> &value, Container &bytes,
            std::size_t &current_index, std::size_t &end_index,
            std::error_code &error_code) {
-
+  // clear out the value - this ensures that value will be only what is read
+  // from the stream, and not any previous data that may have been set during
+  // the construction of the containing object T().
+  value.clear();
   if (current_index >= end_index) {
     // end of input
     // return true for forward compatibility


### PR DESCRIPTION
If I have a struct with a `std::string` in it that has a default value, e.g.

```c++
struct MyStruct {
  std::string my_string = "default_value";
};
```

And I want to serialize an instance of that struct such as:

```c++
MyStruct my_struct {.my_string = "custom_value"};
```

It will serialize properly, containing only the length byte and the bytes for `"custom_value"`.

However, when I deserialize it I will get a struct which contains a string:

```c++
"default_valuecustom_value"
```

This is because the deserialization creates a default instance of the struct (using `T()`), and then the string `from_bytes(...)` does a `value += character` for each byte in the stream.

This PR fixes that by clearing out the string when deserializing it, so that the deserialized struct's string will only contain
```c++
"custom_value"
```