### PR TITLE
Fixed serialization of type requiring "size" information in uint32_t or uint64_t instead of size_t, added `options::force_aligned_access`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ target_include_directories(alpaca INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
 
-if(ALPACA_BUILD_TESTS)
+#if(ALPACA_BUILD_TESTS)
   add_subdirectory(test)
-endif()
+#endif()
 
 if(ALPACA_BUILD_SAMPLES)
   add_subdirectory(samples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ target_include_directories(alpaca INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
 
-#if(ALPACA_BUILD_TESTS)
-  add_subdirectory(test)
-#endif()
+if(ALPACA_BUILD_TESTS)
+add_subdirectory(test)
+endif()
 
 if(ALPACA_BUILD_SAMPLES)
   add_subdirectory(samples)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The source for the above example can be found [here](https://github.com/p-ranav/
      *    [Data Structure Versioning](#data-structure-versioning)
      *    [Integrity Checking with Checksums](#integrity-checking-with-checksums)
      *    [Macros to Exclude STL Data Structures](#macros-to-exclude-stl-data-structures)
+     *    [Aligned Memory Access](#aligned-memory-access)
 *    [Python Interoperability](#python-interoperability)
      *    [Usage](#usage)
      *    [Format String Specification](#format-string-specification)
@@ -1161,6 +1162,15 @@ int main() {
   auto bytes_written = serialize<options::fixed_length_encoding>(s, bytes);
 }
 ```
+### Aligned Memory Access
+
+The Alpaca library, by default, utilizes unaligned memory access, as this is permitted on the x86_64 architecture. 
+However, certain architectures, such as the Arm Cortex-M3, M4, and M33, require aligned memory access for 32-bit 
+and 64-bit data types.
+
+For architectures where aligned memory access is necessary, the Alpaca library includes the 
+```options::force_aligned_access``` option.
+When this option is enabled, the library will not perform unaligned accesses and will use ```memcpy``` instead.
 
 ## Python Interoperability
 

--- a/include/alpaca/detail/field_type.h
+++ b/include/alpaca/detail/field_type.h
@@ -37,7 +37,6 @@ enum class field_type : uint8_t {
   deque,
   filesystem_path,
   bitset,
-  temperature
 };
 
 template <field_type value> constexpr uint8_t to_byte() {

--- a/include/alpaca/detail/field_type.h
+++ b/include/alpaca/detail/field_type.h
@@ -36,7 +36,8 @@ enum class field_type : uint8_t {
   list,
   deque,
   filesystem_path,
-  bitset
+  bitset,
+  temperature
 };
 
 template <field_type value> constexpr uint8_t to_byte() {

--- a/include/alpaca/detail/from_bytes.h
+++ b/include/alpaca/detail/from_bytes.h
@@ -19,9 +19,10 @@ void get_aligned(T& value, const uint8_t* bytes, size_t current_index)
   if (force_aligned_access<O>() &&
       reinterpret_cast<uintptr_t>(bytes + current_index) % alignof(T) != 0)
   {
-    // non-aligned access
+    // non-aligned access --> byte-byte copy
     std::memcpy(&value, bytes + current_index, sizeof(T));
   } else {
+    // aligned access, directly assign the value
     value = *(reinterpret_cast<const T *>(bytes + current_index));
   }
 }

--- a/include/alpaca/detail/from_bytes.h
+++ b/include/alpaca/detail/from_bytes.h
@@ -3,6 +3,7 @@
 #include <alpaca/detail/options.h>
 #include <alpaca/detail/variable_length_encoding.h>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <system_error>
@@ -11,6 +12,20 @@
 namespace alpaca {
 
 namespace detail {
+
+template <options O, typename T>
+void get_aligned(T& value, const uint8_t* bytes, size_t current_index)
+{
+  if (force_aligned_access<O>() &&
+      reinterpret_cast<uintptr_t>(bytes + current_index) % alignof(T) != 0)
+  {
+    // non-aligned access
+    std::memcpy(&value, bytes + current_index, sizeof(T));
+  } else {
+    value = *(reinterpret_cast<const T *>(bytes + current_index));
+  }
+}
+
 
 template <options O, typename Container>
 typename std::enable_if<!std::is_array_v<Container>, bool>::type
@@ -21,7 +36,9 @@ from_bytes_crc32(uint32_t &value, Container &bytes, std::size_t &current_index,
   if (end_index < num_bytes_to_read) {
     return false;
   }
-  value = *(reinterpret_cast<const uint32_t *>(bytes.data() + current_index));
+
+  get_aligned<O>(value, &bytes[0], current_index);
+
   update_value_based_on_alpaca_endian_rules<O, uint32_t>(value);
   current_index += num_bytes_to_read;
   return true;
@@ -36,7 +53,9 @@ from_bytes_crc32(uint32_t &value, Container &bytes, std::size_t &current_index,
   if (end_index < num_bytes_to_read) {
     return false;
   }
-  value = *(reinterpret_cast<const uint32_t *>(bytes + current_index));
+
+  get_aligned<O>(value, &bytes[0], current_index);
+
   update_value_based_on_alpaca_endian_rules<O, uint32_t>(value);
   current_index += num_bytes_to_read;
   return true;
@@ -87,7 +106,8 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     /// TODO: report error
     return false;
   }
-  value = *(reinterpret_cast<const T *>(bytes.data() + current_index));
+
+  get_aligned<O>(value, &bytes[0], current_index);
   current_index += num_bytes_to_read;
   update_value_based_on_alpaca_endian_rules<O, T>(value);
   return true;
@@ -139,7 +159,8 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     /// TODO: report error
     return false;
   }
-  value = *(reinterpret_cast<const T *>(bytes + current_index));
+
+  get_aligned<O>(value, &bytes[0], current_index);
   current_index += num_bytes_to_read;
   update_value_based_on_alpaca_endian_rules<O, T>(value);
   return true;
@@ -194,7 +215,8 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
   char value_bytes[num_bytes_to_read];
   bytes.read(&value_bytes[0], num_bytes_to_read);
   current_index += num_bytes_to_read;
-  value = *(reinterpret_cast<const T *>(value_bytes));
+  get_aligned<O>(value, (uint8_t*) &value_bytes[0], 0);
+
   update_value_based_on_alpaca_endian_rules<O, T>(value);
   return true;
 }
@@ -237,7 +259,7 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
       /// TODO: report error
       return false;
     }
-    value = *(reinterpret_cast<const T *>(bytes.data() + current_index));
+    get_aligned<O>(value, &bytes[0], current_index);
     current_index += num_bytes_to_read;
   } else {
     value = decode_varint<T>(bytes, current_index);
@@ -286,7 +308,7 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
       /// TODO: report error
       return false;
     }
-    value = *(reinterpret_cast<const T *>(bytes + current_index));
+    get_aligned<O>(value, &bytes[0], current_index);
     current_index += num_bytes_to_read;
   } else {
     value = decode_varint<T>(bytes, current_index);
@@ -338,7 +360,7 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     char value_bytes[num_bytes_to_read];
     bytes.read(&value_bytes[0], num_bytes_to_read);
     current_index += num_bytes_to_read;
-    value = *(reinterpret_cast<const T *>(value_bytes));
+    get_aligned<O>(value, (uint8_t*) &value_bytes[0], 0);
   } else {
     value = decode_varint<T>(bytes, current_index);
   }

--- a/include/alpaca/detail/options.h
+++ b/include/alpaca/detail/options.h
@@ -25,6 +25,9 @@ operator|(E lhs, E rhs) {
 
 namespace detail {
 
+using size_t_serialized_type = uint64_t;
+
+
 template <typename T, T value, T flag> constexpr bool enum_has_flag() {
   using underlying = typename std::underlying_type<T>::type;
   return (static_cast<underlying>(value) & static_cast<underlying>(flag)) ==

--- a/include/alpaca/detail/options.h
+++ b/include/alpaca/detail/options.h
@@ -25,7 +25,7 @@ operator|(E lhs, E rhs) {
 
 namespace detail {
 
-using size_t_serialized_type = uint64_t;
+using size_t_serialized_type = uint32_t;
 
 
 template <typename T, T value, T flag> constexpr bool enum_has_flag() {

--- a/include/alpaca/detail/options.h
+++ b/include/alpaca/detail/options.h
@@ -8,7 +8,8 @@ enum class options {
   big_endian = 1,
   fixed_length_encoding = 2,
   with_version = 4,
-  with_checksum = 8
+  with_checksum = 8,
+  force_aligned_access = 16,
 };
 
 template <typename E> struct enable_bitmask_operators {
@@ -50,6 +51,11 @@ template <options O> constexpr bool with_version() {
 
 template <options O> constexpr bool with_checksum() {
   return enum_has_flag<options, O, options::with_checksum>();
+
+}
+
+template <options O> constexpr bool force_aligned_access() {
+  return enum_has_flag<options, O, options::force_aligned_access>();
 }
 
 } // namespace detail

--- a/include/alpaca/detail/to_bytes.h
+++ b/include/alpaca/detail/to_bytes.h
@@ -47,11 +47,13 @@ to_bytes(T &bytes, std::size_t &byte_index, const U &original_value) {
 // encode as variable-length
 template <options O, typename T, typename U>
 typename std::enable_if<
-    std::is_same_v<U, uint32_t> || std::is_same_v<U, uint64_t> ||
-        std::is_same_v<U, int32_t> || std::is_same_v<U, long> || std::is_same_v<U, int64_t> ||
-        std::is_same_v<U, std::size_t>,
+     std::is_same_v<U, uint32_t> || std::is_same_v<U, uint64_t> ||
+     std::is_same_v<U, int32_t> || std::is_same_v<U, long> ||
+     std::is_same_v<U, int64_t>,
     void>::type
 to_bytes(T &bytes, std::size_t &byte_index, const U &original_value) {
+
+  static_assert(!std::is_same_v<T, size_t>, "Unable to directly serialize size_t type");
 
   U value = original_value;
   update_value_based_on_alpaca_endian_rules<O, U>(value);

--- a/include/alpaca/detail/types/array.h
+++ b/include/alpaca/detail/types/array.h
@@ -14,7 +14,7 @@ typename std::enable_if<is_array_type<T>::value, void>::type type_info(
     std::vector<uint8_t> &typeids,
     std::unordered_map<std::string_view, std::size_t> &struct_visitor_map) {
   typeids.push_back(to_byte<field_type::array>());
-  typeids.push_back(std::tuple_size_v<T>);
+  typeids.push_back((size_t_serialized_type) std::tuple_size_v<T>);
   using value_type = typename T::value_type;
   type_info<value_type>(typeids, struct_visitor_map);
 }
@@ -41,7 +41,7 @@ void from_bytes_to_array(T &value, Container &bytes, std::size_t &current_index,
 
   using decayed_value_type = typename std::decay<typename T::value_type>::type;
 
-  constexpr auto size = std::tuple_size<T>::value;
+  constexpr auto size = (size_t_serialized_type) std::tuple_size<T>::value;
 
   if (size > end_index - current_index) {
     // size is greater than the number of bytes remaining
@@ -52,7 +52,7 @@ void from_bytes_to_array(T &value, Container &bytes, std::size_t &current_index,
   }
 
   // read `size` bytes and save to value
-  for (std::size_t i = 0; i < size; ++i) {
+  for (size_t_serialized_type i = 0; i < size; ++i) {
     decayed_value_type v{};
     from_bytes_router<O>(v, bytes, current_index, end_index, error_code);
     value[i] = v;

--- a/include/alpaca/detail/types/bitset.h
+++ b/include/alpaca/detail/types/bitset.h
@@ -26,7 +26,7 @@ template <options O, std::size_t N, typename Container>
 void to_bytes_from_bitset_type(const std::bitset<N> &input, Container &bytes,
                                std::size_t &byte_index) {
   // save bitset size
-  to_bytes_router<O, std::size_t>(input.size(), bytes, byte_index);
+  to_bytes_router<O, size_t_serialized_type>((size_t_serialized_type) input.size(), bytes, byte_index);
 
   // serialize the bitset itself into (bits/8 + 1) bytes
   int num_bytes = input.size() / 8 + 1;
@@ -63,8 +63,8 @@ bool from_bytes_to_bitset(std::bitset<N> &value, Container &bytes,
   }
 
   // current byte is the size of the vector
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size != N) {
@@ -90,7 +90,7 @@ bool from_bytes_to_bitset(std::bitset<N> &value, Container &bytes,
   // reset the value to 0
   value.reset();
 
-  for (std::size_t i = 0; i < num_serialized_bytes; ++i) {
+  for (size_t_serialized_type i = 0; i < num_serialized_bytes; ++i) {
     uint8_t byte{};
     from_bytes_router<O>(byte, bytes, current_index, end_index, error_code);
     if (error_code) {

--- a/include/alpaca/detail/types/deque.h
+++ b/include/alpaca/detail/types/deque.h
@@ -26,7 +26,7 @@ template <options O, typename T, typename Container>
 void to_bytes_from_deque_type(const T &input, Container &bytes,
                               std::size_t &byte_index) {
   // save deque size
-  to_bytes_router<O, std::size_t>(input.size(), bytes, byte_index);
+  to_bytes_router<O, size_t_serialized_type>(input.size(), bytes, byte_index);
 
   // value of each element in deque
   for (const auto &v : input) {
@@ -57,8 +57,8 @@ bool from_bytes_to_deque(std::deque<T> &value, Container &bytes,
   }
 
   // current byte is the size of the vector
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size > end_index - current_index) {
@@ -70,7 +70,7 @@ bool from_bytes_to_deque(std::deque<T> &value, Container &bytes,
   }
 
   // read `size` bytes and save to value
-  for (std::size_t i = 0; i < size; ++i) {
+  for (size_t_serialized_type i = 0; i < size; ++i) {
     T v{};
     from_bytes_router<O>(v, bytes, current_index, end_index, error_code);
     if (error_code) {

--- a/include/alpaca/detail/types/filesystem_path.h
+++ b/include/alpaca/detail/types/filesystem_path.h
@@ -26,7 +26,8 @@ template <options O, typename Container>
 void to_bytes(Container &bytes, std::size_t &byte_index,
               const std::filesystem::path &input) {
   // save string length
-  to_bytes_router<O>(input.native().size(), bytes, byte_index);
+  to_bytes_router<O>((size_t_serialized_type)input.native().size(), bytes,
+                     byte_index);
 
   for (const auto &c : input.native()) {
     to_bytes<O>(bytes, byte_index, c);
@@ -35,8 +36,8 @@ void to_bytes(Container &bytes, std::size_t &byte_index,
 
 template <options O, typename Container>
 bool from_bytes(std::filesystem::path &value, Container &bytes,
-           std::size_t &current_index, std::size_t &end_index,
-           std::error_code &error_code) {
+                std::size_t &current_index, std::size_t &end_index,
+                std::error_code &error_code) {
 
   if (current_index >= end_index) {
     // end of input
@@ -45,9 +46,9 @@ bool from_bytes(std::filesystem::path &value, Container &bytes,
   }
 
   // current byte is the length of the string
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
-                                     error_code);
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index,
+                                                end_index, error_code);
 
   if (size > end_index - current_index) {
     // size is greater than the number of bytes remaining

--- a/include/alpaca/detail/types/list.h
+++ b/include/alpaca/detail/types/list.h
@@ -26,7 +26,7 @@ template <options O, typename T, typename Container>
 void to_bytes_from_list_type(const T &input, Container &bytes,
                              std::size_t &byte_index) {
   // save list size
-  to_bytes_router<O, std::size_t>(input.size(), bytes, byte_index);
+  to_bytes_router<O, size_t_serialized_type>(input.size(), bytes, byte_index);
 
   // value of each element in list
   for (const auto &v : input) {
@@ -57,8 +57,8 @@ bool from_bytes_to_list(std::list<T> &value, Container &bytes,
   }
 
   // current byte is the size of the vector
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size > end_index - current_index) {

--- a/include/alpaca/detail/types/map.h
+++ b/include/alpaca/detail/types/map.h
@@ -51,7 +51,7 @@ template <options O, typename T, typename Container>
 void to_bytes_from_map_type(const T &input, Container &bytes,
                             std::size_t &byte_index) {
   // save map size
-  to_bytes_router<O, std::size_t, Container>(input.size(), bytes, byte_index);
+  to_bytes_router<O, size_t_serialized_type, Container>((size_t_serialized_type) input.size(), bytes, byte_index);
 
   // save key,value pairs in map
   for (const auto &[key, value] : input) {
@@ -84,8 +84,8 @@ template <options O, typename T, typename Container>
 void from_bytes_to_map(T &map, Container &bytes, std::size_t &current_index,
                        std::size_t &end_index, std::error_code &error_code) {
   // current byte is the size of the map
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size > end_index - current_index) {

--- a/include/alpaca/detail/types/set.h
+++ b/include/alpaca/detail/types/set.h
@@ -50,7 +50,7 @@ template <options O, typename T, typename Container>
 void to_bytes_from_set_type(const T &input, Container &bytes,
                             std::size_t &byte_index) {
   // save set size
-  to_bytes_router<O, std::size_t, Container>(input.size(), bytes, byte_index);
+  to_bytes_router<O, size_t_serialized_type, Container>((size_t_serialized_type) input.size(), bytes, byte_index);
 
   // save values in set
   for (const auto &value : input) {
@@ -82,8 +82,8 @@ template <options O, typename T, typename Container>
 void from_bytes_to_set(T &set, Container &bytes, std::size_t &current_index,
                        std::size_t &end_index, std::error_code &error_code) {
   // current byte is the size of the set
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size > end_index - current_index) {

--- a/include/alpaca/detail/types/string.h
+++ b/include/alpaca/detail/types/string.h
@@ -26,7 +26,7 @@ template <options O, typename Container, typename CharType>
 void to_bytes(Container &bytes, std::size_t &byte_index,
               const std::basic_string<CharType> &input) {
   // save string length
-  to_bytes_router<O>(input.size(), bytes, byte_index);
+  to_bytes_router<O>((size_t_serialized_type) input.size(), bytes, byte_index);
 
   for (const auto &c : input) {
     to_bytes<O>(bytes, byte_index, c);
@@ -49,8 +49,8 @@ from_bytes(std::basic_string<CharType> &value, Container &bytes,
   }
 
   // current byte is the length of the string
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size > end_index - current_index) {
@@ -89,8 +89,8 @@ from_bytes(std::basic_string<CharType> &value, Container &bytes,
   }
 
   // current byte is the length of the string
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size > end_index - current_index) {

--- a/include/alpaca/detail/types/tuple.h
+++ b/include/alpaca/detail/types/tuple.h
@@ -30,7 +30,7 @@ type_info(
     std::vector<uint8_t> &typeids,
     std::unordered_map<std::string_view, std::size_t> &struct_visitor_map) {
   typeids.push_back(to_byte<field_type::tuple>());
-  constexpr auto tuple_size = std::tuple_size_v<T>;
+  constexpr auto tuple_size = (size_t_serialized_type) std::tuple_size_v<T>;
   type_info_tuple_helper<T, tuple_size, 0>(typeids, struct_visitor_map);
 }
 

--- a/include/alpaca/detail/types/vector.h
+++ b/include/alpaca/detail/types/vector.h
@@ -26,7 +26,7 @@ template <options O, typename T, typename Container>
 void to_bytes_from_vector_type(const T &input, Container &bytes,
                                std::size_t &byte_index) {
   // save vector size
-  to_bytes_router<O, std::size_t>(input.size(), bytes, byte_index);
+  to_bytes_router<O, size_t_serialized_type>((size_t_serialized_type) input.size(), bytes, byte_index);
 
   // value of each element in list
   for (const auto &v : input) {
@@ -65,8 +65,8 @@ bool from_bytes_to_vector(std::vector<T> &value, Container &bytes,
   }
 
   // current byte is the size of the vector
-  std::size_t size = 0;
-  detail::from_bytes<O, std::size_t>(size, bytes, current_index, end_index,
+  size_t_serialized_type size = 0;
+  detail::from_bytes<O, size_t_serialized_type>(size, bytes, current_index, end_index,
                                      error_code);
 
   if (size > end_index - current_index) {

--- a/test/test_deserialize_from_ifstream.cpp
+++ b/test/test_deserialize_from_ifstream.cpp
@@ -75,8 +75,9 @@ TEST_CASE("Deserialize complex struct from ifstream with options" *
     os.open("tmp2.bin", std::ios::out | std::ios::binary);
     auto bytes_written = serialize<OPTIONS>(s, os);
     os.close();
-    REQUIRE(bytes_written == 117);
-    REQUIRE(std::filesystem::file_size("tmp2.bin") == 117);
+    constexpr auto expected = 93 + sizeof(alpaca::detail::size_t_serialized_type);
+    REQUIRE(bytes_written == expected);
+    REQUIRE(std::filesystem::file_size("tmp2.bin") == expected);
   }
 
   {

--- a/test/test_extended_serialize_deserialize.cpp
+++ b/test/test_extended_serialize_deserialize.cpp
@@ -1,0 +1,462 @@
+#include <alpaca/alpaca.h>
+#include <doctest.hpp>
+using namespace alpaca;
+
+using doctest::test_suite;
+
+constexpr auto OPTIONS = options::fixed_length_encoding;
+
+TEST_SUITE("extended test") {
+
+  TEST_CASE("Fixed length encoding") {
+
+    struct Simple {
+      uint32_t field{0};
+    };
+
+    Simple data{0x12345678};
+
+    std::vector<uint8_t> bytes;
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Simple>(bytes, err);
+
+    REQUIRE(!err);
+
+    REQUIRE(reconstructed.field == data.field); // And here it dies.
+  }
+
+  TEST_CASE("Nested Structs") {
+    struct Inner {
+      uint32_t field1{0};
+      std::string field2;
+    };
+
+    struct Outer {
+      Inner inner;
+      uint32_t field3{0};
+    };
+
+    Outer data{{0x12345678, "test"}, 0x87654321};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.inner.field1 == data.inner.field1);
+    REQUIRE(reconstructed.inner.field2 == data.inner.field2);
+    REQUIRE(reconstructed.field3 == data.field3);
+  }
+
+  TEST_CASE("Vector of Custom Structs") {
+    struct Item {
+      uint32_t id{0};
+      std::string name;
+    };
+
+    struct Container {
+      std::vector<Item> items;
+    };
+
+    Container data{{{1, "item1"}, {2, "item2"}, {3, "item3"}}};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Container>(bytes, err);
+    REQUIRE(!err);
+
+    REQUIRE(reconstructed.items.size() == data.items.size());
+    for (size_t i = 0; i < data.items.size(); ++i) {
+      REQUIRE(reconstructed.items[i].id == data.items[i].id);
+      REQUIRE(reconstructed.items[i].name == data.items[i].name);
+    }
+  }
+
+  TEST_CASE("Struct with String") {
+    struct SimpleWithString {
+      uint32_t id{0};
+      std::string name;
+    };
+
+    SimpleWithString data{0x12345678, "test"};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed =
+        alpaca::deserialize<OPTIONS, SimpleWithString>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.id == data.id);
+    REQUIRE(reconstructed.name == data.name);
+  }
+
+  // Aggiungi qui altri casi di test...
+  TEST_CASE("Complex Nested Structs and Vectors") {
+    struct Inner {
+      uint32_t id{0};
+      std::string name;
+    };
+
+    struct Middle {
+      Inner inner;
+      std::vector<Inner> innerList;
+    };
+
+    struct Outer {
+      Middle middle;
+      std::string description;
+    };
+
+    Outer data{{{0x1, "inner1"}, {{0x2, "inner2"}, {0x3, "inner3"}}},
+               "complex structure"};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.middle.inner.id == data.middle.inner.id);
+    REQUIRE(reconstructed.middle.inner.name == data.middle.inner.name);
+    REQUIRE(reconstructed.middle.innerList.size() ==
+            data.middle.innerList.size());
+    for (size_t i = 0; i < data.middle.innerList.size(); ++i) {
+      REQUIRE(reconstructed.middle.innerList[i].id ==
+              data.middle.innerList[i].id);
+      REQUIRE(reconstructed.middle.innerList[i].name ==
+              data.middle.innerList[i].name);
+    }
+    REQUIRE(reconstructed.description == data.description);
+  }
+
+  TEST_CASE("Backwards Compatibility (new field added in struct)") {
+    struct Simple {
+      uint32_t field{0};
+    };
+
+    Simple data{0x12345678};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Simple>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.field == data.field);
+  }
+
+  // Altri casi di test...
+
+  TEST_CASE("long strings") {
+    struct WithLongString {
+      std::string long_string;
+    };
+
+    WithLongString data{"Questo è un test con una stringa molto lunga. " +
+                        std::string(1000, 'A')};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed =
+        alpaca::deserialize<OPTIONS, WithLongString>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.long_string == data.long_string);
+  }
+
+  TEST_CASE("empty strings") {
+    struct WithNullString {
+      std::string null_string;
+    };
+
+    WithNullString data{""};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed =
+        alpaca::deserialize<OPTIONS, WithNullString>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.null_string == data.null_string);
+  }
+
+  TEST_CASE("32-bit extremes") {
+    struct WithExtremeInt32 {
+      int32_t min_int{-(2 ^ 31)};
+      int32_t max_int{(2 ^ 31) - 1};
+    };
+
+    WithExtremeInt32 data;
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed =
+        alpaca::deserialize<OPTIONS, WithExtremeInt32>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.min_int == data.min_int);
+    REQUIRE(reconstructed.max_int == data.max_int);
+  }
+
+  TEST_CASE("64-bit extreme") {
+    struct WithExtremeInt64 {
+      int64_t min_int{-(2 ^ 63)};
+      int64_t max_int{(2 ^ 63) - 1};
+    };
+
+    WithExtremeInt64 data;
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed =
+        alpaca::deserialize<OPTIONS, WithExtremeInt64>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.min_int == data.min_int);
+    REQUIRE(reconstructed.max_int == data.max_int);
+  }
+
+  TEST_CASE("Nested Structs with Extreme Values") {
+    struct Inner {
+      int32_t min_int{-(2 ^ 31)};
+      int32_t max_int{(2 ^ 31) - 1};
+      std::string long_string;
+    };
+
+    struct Outer {
+      Inner inner;
+      int64_t extreme_value{(2 ^ 63) - 1};
+    };
+
+    Outer data{{-(2 ^ 31), (2 ^ 31) - 1, std::string(1000, 'A')}, (2 ^ 63) - 1};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.inner.min_int == data.inner.min_int);
+    REQUIRE(reconstructed.inner.max_int == data.inner.max_int);
+    REQUIRE(reconstructed.inner.long_string == data.inner.long_string);
+    REQUIRE(reconstructed.extreme_value == data.extreme_value);
+  }
+
+  TEST_CASE("Complex Nested Structs and Vectors with Extremes") {
+    struct Inner {
+      int32_t min_int{-(2 ^ 31)};
+      int32_t max_int{(2 ^ 31) - 1};
+      std::string long_string;
+    };
+
+    struct Middle {
+      Inner inner;
+      std::vector<Inner> innerList;
+    };
+
+    struct Outer {
+      Middle middle;
+      std::string description;
+    };
+
+    Outer data{{{-(2 ^ 31), (2 ^ 31) - 1, std::string(1000, 'A')},
+                {{-(2 ^ 31), (2 ^ 31) - 1, std::string(500, 'B')},
+                 {-(2 ^ 31), (2 ^ 31) - 1, std::string(500, 'C')}}},
+               "complex structure with extremes"};
+
+    std::vector<uint8_t> bytes;
+
+    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
+
+    REQUIRE(!err);
+    REQUIRE(reconstructed.middle.inner.min_int == data.middle.inner.min_int);
+    REQUIRE(reconstructed.middle.inner.max_int == data.middle.inner.max_int);
+    REQUIRE(reconstructed.middle.inner.long_string ==
+            data.middle.inner.long_string);
+    REQUIRE(reconstructed.middle.innerList.size() ==
+            data.middle.innerList.size());
+    for (size_t i = 0; i < data.middle.innerList.size(); ++i) {
+      REQUIRE(reconstructed.middle.innerList[i].min_int ==
+              data.middle.innerList[i].min_int);
+      REQUIRE(reconstructed.middle.innerList[i].max_int ==
+              data.middle.innerList[i].max_int);
+      REQUIRE(reconstructed.middle.innerList[i].long_string ==
+              data.middle.innerList[i].long_string);
+    }
+    REQUIRE(reconstructed.description == data.description);
+  }
+
+  // Ripeti per altri 95 casi di test...
+}
+
+enum class Status { ACTIVE, INACTIVE, PENDING, DELETED };
+
+struct Detail {
+  int32_t id{0};
+  int64_t value1{0};
+  int64_t value2{0};
+  double ratio{0.0};
+  std::string description;
+  uint32_t count{0};
+  bool flag{false};
+  std::string note;
+  float balance{0.0f};
+  char initial{'A'};
+  uint64_t big_value{0};
+  int16_t short_value{0};
+  Status status{Status::ACTIVE};
+  std::vector<int> numbers;
+  std::string metadata;
+};
+
+struct Complex {
+  int32_t field1{0};
+  int64_t field2{0};
+  std::string field3;
+  double field4{0.0};
+  Status status{Status::ACTIVE};
+  std::vector<Detail> details;
+  bool flag{false};
+  uint32_t field5{0};
+  float field6{0.0f};
+  std::string field7;
+  char field8{'A'};
+  uint64_t field9{0};
+  int16_t field10{0};
+};
+
+TEST_CASE("Complex Struct with Many Fields and Vector of Detailed Structs") {
+  Complex data{
+      0x12345678,              // field1
+      0x123456789ABCDEF0,      // field2
+      "This is a test string", // field3
+      1234.5678,               // field4
+      Status::PENDING,         // status
+      {                        // details
+       {1,
+        100,
+        200,
+        0.1,
+        "Detail 1",
+        10,
+        true,
+        "Note 1",
+        10.5f,
+        'B',
+        0xFFFFFFFF,
+        1000,
+        Status::ACTIVE,
+        {1, 2, 3},
+        "Meta 1"},
+       {2,
+        200,
+        400,
+        0.2,
+        "Detail 2",
+        20,
+        false,
+        "Note 2",
+        20.5f,
+        'C',
+        0xFFFFFFFE,
+        2000,
+        Status::INACTIVE,
+        {4, 5, 6},
+        "Meta 2"},
+       {3,
+        300,
+        600,
+        0.3,
+        "Detail 3",
+        30,
+        true,
+        "Note 3",
+        30.5f,
+        'D',
+        0xFFFFFFFD,
+        3000,
+        Status::DELETED,
+        {7, 8, 9},
+        "Meta 3"}},
+      true,                  // flag
+      0x87654321,            // field5
+      5678.1234f,            // field6
+      "Another test string", // field7
+      'Z',                   // field8
+      0xFEDCBA9876543210,    // field9
+      -32768                 // field10
+  };
+
+  std::vector<uint8_t> bytes;
+  auto size = alpaca::serialize<OPTIONS>(data, bytes);
+
+  std::error_code err;
+  auto reconstructed = alpaca::deserialize<OPTIONS, Complex>(bytes, err);
+
+  REQUIRE(!err);
+  REQUIRE(reconstructed.field1 == data.field1);
+  REQUIRE(reconstructed.field2 == data.field2);
+  REQUIRE(reconstructed.field3 == data.field3);
+  REQUIRE(reconstructed.field4 == data.field4);
+  REQUIRE(reconstructed.status == data.status);
+  REQUIRE(reconstructed.flag == data.flag);
+  REQUIRE(reconstructed.field5 == data.field5);
+  REQUIRE(reconstructed.field6 == data.field6);
+  REQUIRE(reconstructed.field7 == data.field7);
+  REQUIRE(reconstructed.field8 == data.field8);
+  REQUIRE(reconstructed.field9 == data.field9);
+  REQUIRE(reconstructed.field10 == data.field10);
+
+  REQUIRE(reconstructed.details.size() == data.details.size());
+  for (size_t i = 0; i < data.details.size(); ++i) {
+    REQUIRE(reconstructed.details[i].id == data.details[i].id);
+    REQUIRE(reconstructed.details[i].value1 == data.details[i].value1);
+    REQUIRE(reconstructed.details[i].value2 == data.details[i].value2);
+    REQUIRE(reconstructed.details[i].ratio == data.details[i].ratio);
+    REQUIRE(reconstructed.details[i].description ==
+            data.details[i].description);
+    REQUIRE(reconstructed.details[i].count == data.details[i].count);
+    REQUIRE(reconstructed.details[i].flag == data.details[i].flag);
+    REQUIRE(reconstructed.details[i].note == data.details[i].note);
+    REQUIRE(reconstructed.details[i].balance == data.details[i].balance);
+    REQUIRE(reconstructed.details[i].initial == data.details[i].initial);
+    REQUIRE(reconstructed.details[i].big_value == data.details[i].big_value);
+    REQUIRE(reconstructed.details[i].short_value ==
+            data.details[i].short_value);
+    REQUIRE(reconstructed.details[i].status == data.details[i].status);
+    REQUIRE(reconstructed.details[i].numbers == data.details[i].numbers);
+    REQUIRE(reconstructed.details[i].metadata == data.details[i].metadata);
+  }
+}

--- a/test/test_extended_serialize_deserialize.cpp
+++ b/test/test_extended_serialize_deserialize.cpp
@@ -17,7 +17,7 @@ TEST_SUITE("extended test") {
     Simple data{0x12345678};
 
     std::vector<uint8_t> bytes;
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed = alpaca::deserialize<OPTIONS, Simple>(bytes, err);
@@ -42,7 +42,7 @@ TEST_SUITE("extended test") {
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
@@ -67,7 +67,7 @@ TEST_SUITE("extended test") {
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed = alpaca::deserialize<OPTIONS, Container>(bytes, err);
@@ -90,7 +90,7 @@ TEST_SUITE("extended test") {
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed =
@@ -123,7 +123,7 @@ TEST_SUITE("extended test") {
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
@@ -151,7 +151,7 @@ TEST_SUITE("extended test") {
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed = alpaca::deserialize<OPTIONS, Simple>(bytes, err);
@@ -172,7 +172,7 @@ TEST_SUITE("extended test") {
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed =
@@ -191,7 +191,7 @@ TEST_SUITE("extended test") {
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed =
@@ -203,15 +203,15 @@ TEST_SUITE("extended test") {
 
   TEST_CASE("32-bit extremes") {
     struct WithExtremeInt32 {
-      int32_t min_int{-(2 ^ 31)};
-      int32_t max_int{(2 ^ 31) - 1};
+      int32_t min_int{std::numeric_limits<int32_t>::min()};
+      int32_t max_int{std::numeric_limits<int32_t>::max()};
     };
 
     WithExtremeInt32 data;
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed =
@@ -224,15 +224,15 @@ TEST_SUITE("extended test") {
 
   TEST_CASE("64-bit extreme") {
     struct WithExtremeInt64 {
-      int64_t min_int{-(2 ^ 63)};
-      int64_t max_int{(2 ^ 63) - 1};
+      int64_t min_int{std::numeric_limits<int64_t>::min()};
+      int64_t max_int{std::numeric_limits<int64_t>::max()};
     };
 
     WithExtremeInt64 data;
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed =
@@ -245,21 +245,23 @@ TEST_SUITE("extended test") {
 
   TEST_CASE("Nested Structs with Extreme Values") {
     struct Inner {
-      int32_t min_int{-(2 ^ 31)};
-      int32_t max_int{(2 ^ 31) - 1};
+      int32_t min_int{std::numeric_limits<int32_t>::min()};
+      int32_t max_int{std::numeric_limits<int32_t>::max()};
       std::string long_string;
     };
 
     struct Outer {
       Inner inner;
-      int64_t extreme_value{(2 ^ 63) - 1};
+      int64_t extreme_value{std::numeric_limits<int64_t>::max()};
     };
 
-    Outer data{{-(2 ^ 31), (2 ^ 31) - 1, std::string(1000, 'A')}, (2 ^ 63) - 1};
+    Outer data{{std::numeric_limits<int32_t>::max(),
+                std::numeric_limits<int32_t>::min(), std::string(1000, 'A')},
+               std::numeric_limits<int64_t>::max()};
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
@@ -273,8 +275,8 @@ TEST_SUITE("extended test") {
 
   TEST_CASE("Complex Nested Structs and Vectors with Extremes") {
     struct Inner {
-      int32_t min_int{-(2 ^ 31)};
-      int32_t max_int{(2 ^ 31) - 1};
+      int32_t min_int{std::numeric_limits<int32_t>::min()};
+      int32_t max_int{std::numeric_limits<int32_t>::max()};
       std::string long_string;
     };
 
@@ -287,15 +289,17 @@ TEST_SUITE("extended test") {
       Middle middle;
       std::string description;
     };
+    constexpr auto min = std::numeric_limits<int32_t>::min();
+    constexpr auto max = std::numeric_limits<int32_t>::max();
 
-    Outer data{{{-(2 ^ 31), (2 ^ 31) - 1, std::string(1000, 'A')},
-                {{-(2 ^ 31), (2 ^ 31) - 1, std::string(500, 'B')},
-                 {-(2 ^ 31), (2 ^ 31) - 1, std::string(500, 'C')}}},
+    Outer data{{{min, max, std::string(1000, 'A')},
+                {{min, max, std::string(500, 'B')},
+                 {min, max, std::string(500, 'C')}}},
                "complex structure with extremes"};
 
     std::vector<uint8_t> bytes;
 
-    auto size = alpaca::serialize<OPTIONS>(data, bytes);
+    alpaca::serialize<OPTIONS>(data, bytes);
 
     std::error_code err;
     auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
@@ -420,7 +424,7 @@ TEST_CASE("Complex Struct with Many Fields and Vector of Detailed Structs") {
   };
 
   std::vector<uint8_t> bytes;
-  auto size = alpaca::serialize<OPTIONS>(data, bytes);
+  alpaca::serialize<OPTIONS>(data, bytes);
 
   std::error_code err;
   auto reconstructed = alpaca::deserialize<OPTIONS, Complex>(bytes, err);

--- a/test/test_extended_serialize_deserialize.cpp
+++ b/test/test_extended_serialize_deserialize.cpp
@@ -4,7 +4,7 @@ using namespace alpaca;
 
 using doctest::test_suite;
 
-constexpr auto OPTIONS = options::fixed_length_encoding;
+constexpr auto OPTIONS = options::fixed_length_encoding | options::force_aligned_access;
 
 TEST_SUITE("extended test") {
 

--- a/test/test_force_alignment.cpp
+++ b/test/test_force_alignment.cpp
@@ -1,0 +1,73 @@
+#include <alpaca/alpaca.h>
+#include <doctest.hpp>
+using namespace alpaca;
+
+using doctest::test_suite;
+
+constexpr auto OPTIONS = options::fixed_length_encoding | options::force_aligned_access;
+
+TEST_SUITE("unaligned access") {
+
+  TEST_CASE("Complex structure with non-aligned fields") {
+
+    struct Complex {
+      uint8_t byte1{0};      // 1 byte
+      uint32_t field1{0};    // 4 bytes, starts at offset 1
+      uint8_t byte2{0};      // 1 byte, starts at offset 5
+      uint64_t field2{0};    // 8 bytes, starts at offset 6
+      uint32_t field3{0};    // 4 bytes, starts at offset 14
+      uint8_t byte3{0};      // 1 byte, starts at offset 18
+    };
+
+    Complex data{0x01, 0x12345678, 0x02, 0x1234567890ABCDEF, 0xDEADBEEF, 0x03};
+
+    std::vector<uint8_t> bytes;
+    alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Complex>(bytes, err);
+
+    REQUIRE(!err);
+
+    REQUIRE(reconstructed.byte1 == data.byte1);
+    REQUIRE(reconstructed.field1 == data.field1);
+    REQUIRE(reconstructed.byte2 == data.byte2);
+    REQUIRE(reconstructed.field2 == data.field2);
+    REQUIRE(reconstructed.field3 == data.field3);
+    REQUIRE(reconstructed.byte3 == data.byte3);
+  }
+
+  TEST_CASE("Nested structures with non-aligned fields") {
+
+    struct Inner {
+      uint8_t byte1{0};
+      uint64_t field1{0};
+    };
+
+    struct Outer {
+      uint8_t byte2{0};
+      uint32_t field2{0};
+      Inner inner;
+      uint8_t byte3{0};
+      uint64_t field3{0};
+    };
+
+    Outer data{0x04, 0x56789ABC, {0x05, 0x1234567890ABCDEF}, 0x06, 0xFEDCBA9876543210};
+
+    std::vector<uint8_t> bytes;
+    alpaca::serialize<OPTIONS>(data, bytes);
+
+    std::error_code err;
+    auto reconstructed = alpaca::deserialize<OPTIONS, Outer>(bytes, err);
+
+    REQUIRE(!err);
+
+    REQUIRE(reconstructed.byte2 == data.byte2);
+    REQUIRE(reconstructed.field2 == data.field2);
+    REQUIRE(reconstructed.inner.byte1 == data.inner.byte1);
+    REQUIRE(reconstructed.inner.field1 == data.inner.field1);
+    REQUIRE(reconstructed.byte3 == data.byte3);
+    REQUIRE(reconstructed.field3 == data.field3);
+  }
+
+}

--- a/test/test_serialize_to_fstream.cpp
+++ b/test/test_serialize_to_fstream.cpp
@@ -57,7 +57,9 @@ TEST_CASE("Serialize complex struct to fstream with options" *
   os.open("tmp4.bin", std::ios::out | std::ios::binary);
   auto bytes_written = serialize<OPTIONS>(s, os);
   os.close();
-  REQUIRE(bytes_written == 117);
-  REQUIRE(std::filesystem::file_size("tmp4.bin") == 117);
+  constexpr auto expected_size =
+      93 + sizeof(alpaca::detail::size_t_serialized_type);
+  REQUIRE(bytes_written == expected_size);
+  REQUIRE(std::filesystem::file_size("tmp4.bin") == expected_size);
   std::filesystem::remove("tmp4.bin");
 }


### PR DESCRIPTION
This pull request addresses the issue identified in #43 regarding the serialization of size information using `size_t` type, which is not architecture-agnostic.

To ensure consistent serialization across different architectures, the size information for strings, vectors, and other types that require a size attribute is now serialized using a type explicitly defined in alpaca::detail::size_t_serialized_type (uint32_t or uint64_t).
This change guarantees uniformity in the serialized data, irrespective of the platform.
I also aligned the tests and I added a set of test generated by chatgpt.

