### PR TITLE
fix: crc32 should not have byte order be platform dependent

### DIFF
--- a/include/alpaca/detail/crc32.h
+++ b/include/alpaca/detail/crc32.h
@@ -28,11 +28,10 @@
 // size_t
 #include <cstddef>
 
-// define endianess and some integer data types
-#if defined(_MSC_VER) || defined(__MINGW32__)
-// Windows always little endian
 #define __ALPACA_BYTE_ORDER __ALPACA_LITTLE_ENDIAN
 
+// define some integer data types
+#if defined(_MSC_VER) || defined(__MINGW32__)
 // intrinsics / prefetching
 #if defined(__MINGW32__) || defined(__clang__)
 #define ALPACA_PREFETCH(location) __builtin_prefetch(location)
@@ -42,41 +41,30 @@
 #define ALPACA_PREFETCH(location) _mm_prefetch(location, _MM_HINT_T0)
 #else
 #define ALPACA_PREFETCH(location) ;
-#endif
-#endif
+#endif // __SSE2__
+#endif // __MINGW32__
 #elif defined(__APPLE__) || defined(__MACH__)
-// Apple MacOS uses big endian
-#define __ALPACA_BYTE_ORDER __ALPACA_BIG_ENDIAN
-
 // intrinsics / prefetching
 #ifdef __GNUC__
 #define ALPACA_PREFETCH(location) __builtin_prefetch(location)
-#else
+#else // __GNUC__
 // no prefetching
 #define ALPACA_PREFETCH(location) ;
-#endif
+#endif // __GNUC__
 
 #elif defined(__linux__) || defined(__linux) || defined(linux__) ||            \
     defined(__gnu_linux__)
-// defines BYTE_ORDER as __ALPACA_LITTLE_ENDIAN or __ALPACA_BIG_ENDIAN
 #include <sys/param.h>
-#define __ALPACA_BYTE_ORDER __BYTE_ORDER
-
 // intrinsics / prefetching
 #ifdef __GNUC__
 #define ALPACA_PREFETCH(location) __builtin_prefetch(location)
-#else
+#else // __GNUC__
 // no prefetching
 #define ALPACA_PREFETCH(location) ;
-#endif
-#else
+#endif // __GNUC__
+#else // unknown system
 #error unsupported system
-#endif
-
-// abort if byte order is undefined
-#if !defined(__ALPACA_BYTE_ORDER)
-#error undefined byte order, compile with -D__ALPACA_BYTE_ORDER=1234 (if little endian) or -D__ALPACA_BYTE_ORDER=4321 (big endian)
-#endif
+#endif // system
 
 namespace {
 /// zlib's CRC32 polynomial


### PR DESCRIPTION
Previously, the crc32 (if enabled) was being calculated on different platforms according to different byte orderings, which meant that serialized byte streams including CRC which were serialized one one system would not properly deserialize on a system with a different byte order (or for which alpaca had defined a different byte order in crc32).

This PR updates it so that no matter what, the crc32 is always computed in little endian format.