### PR TITLE
feat(options): Add `strict` option to return false if reaching the end of input early

### DIFF
--- a/include/alpaca/detail/from_bytes.h
+++ b/include/alpaca/detail/from_bytes.h
@@ -83,8 +83,13 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     // default initialize the value
     value = T();
 
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, int8_t>) {
@@ -136,8 +141,13 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     // default initialize the value
     value = T();
 
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, int8_t>) {
@@ -189,8 +199,13 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     // default initialize the value
     value = T();
 
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, int8_t>) {
@@ -232,7 +247,7 @@ typename std::enable_if<
          std::is_same_v<T, std::size_t>),
     bool>::type
 from_bytes(T &value, Container &bytes, std::size_t &current_index,
-           std::size_t &end_index, std::error_code &) {
+           std::size_t &end_index, std::error_code &error_code) {
 
   if (current_index >= end_index) {
     // end of input
@@ -240,8 +255,13 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     // default initialize the value
     value = T();
 
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   constexpr auto use_fixed_length_encoding = (
@@ -281,7 +301,7 @@ typename std::enable_if<
          std::is_same_v<T, std::size_t>),
     bool>::type
 from_bytes(T &value, Container &bytes, std::size_t &current_index,
-           std::size_t &end_index, std::error_code &) {
+           std::size_t &end_index, std::error_code &error_code) {
 
   if (current_index >= end_index) {
     // end of input
@@ -289,8 +309,13 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     // default initialize the value
     value = T();
 
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   constexpr auto use_fixed_length_encoding = (
@@ -330,7 +355,7 @@ typename std::enable_if<
          std::is_same_v<T, std::size_t>),
     bool>::type
 from_bytes(T &value, Container &bytes, std::size_t &current_index,
-           std::size_t &end_index, std::error_code &) {
+           std::size_t &end_index, std::error_code &error_code) {
 
   if (current_index >= end_index) {
     // end of input
@@ -338,8 +363,13 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     // default initialize the value
     value = T();
 
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   constexpr auto use_fixed_length_encoding = (
@@ -382,8 +412,13 @@ from_bytes(T &value, Container &bytes, std::size_t &current_index,
     // default initialize the value
     value = T();
 
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   using underlying_type = typename std::underlying_type<T>::type;

--- a/include/alpaca/detail/options.h
+++ b/include/alpaca/detail/options.h
@@ -10,6 +10,7 @@ enum class options {
   with_version = 4,
   with_checksum = 8,
   force_aligned_access = 16,
+  strict = 32,
 };
 
 template <typename E> struct enable_bitmask_operators {
@@ -56,6 +57,10 @@ template <options O> constexpr bool with_checksum() {
 
 template <options O> constexpr bool force_aligned_access() {
   return enum_has_flag<options, O, options::force_aligned_access>();
+}
+
+template <options O> constexpr bool strict() {
+  return enum_has_flag<options, O, options::strict>();
 }
 
 } // namespace detail

--- a/include/alpaca/detail/types/array.h
+++ b/include/alpaca/detail/types/array.h
@@ -66,8 +66,13 @@ bool from_bytes(std::array<U, N> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   from_bytes_to_array<O>(output, bytes, byte_index, end_index, error_code);

--- a/include/alpaca/detail/types/bitset.h
+++ b/include/alpaca/detail/types/bitset.h
@@ -58,8 +58,13 @@ bool from_bytes_to_bitset(std::bitset<N> &value, Container &bytes,
 
   if (current_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the size of the vector

--- a/include/alpaca/detail/types/deque.h
+++ b/include/alpaca/detail/types/deque.h
@@ -52,8 +52,13 @@ bool from_bytes_to_deque(std::deque<T> &value, Container &bytes,
 
   if (current_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the size of the vector

--- a/include/alpaca/detail/types/duration.h
+++ b/include/alpaca/detail/types/duration.h
@@ -44,8 +44,13 @@ bool from_bytes(std::chrono::duration<Rep, Period> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   Rep count{0};

--- a/include/alpaca/detail/types/filesystem_path.h
+++ b/include/alpaca/detail/types/filesystem_path.h
@@ -41,8 +41,13 @@ bool from_bytes(std::filesystem::path &value, Container &bytes,
 
   if (current_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the length of the string

--- a/include/alpaca/detail/types/list.h
+++ b/include/alpaca/detail/types/list.h
@@ -52,8 +52,13 @@ bool from_bytes_to_list(std::list<T> &value, Container &bytes,
 
   if (current_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the size of the vector

--- a/include/alpaca/detail/types/map.h
+++ b/include/alpaca/detail/types/map.h
@@ -116,8 +116,13 @@ bool from_bytes(std::map<K, V> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   from_bytes_to_map<O>(output, bytes, byte_index, end_index, error_code);
@@ -133,8 +138,13 @@ bool from_bytes(std::unordered_map<K, V> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   from_bytes_to_map<O>(output, bytes, byte_index, end_index, error_code);

--- a/include/alpaca/detail/types/optional.h
+++ b/include/alpaca/detail/types/optional.h
@@ -47,8 +47,13 @@ bool from_bytes(std::optional<T> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   auto current_byte = bytes[byte_index];

--- a/include/alpaca/detail/types/pair.h
+++ b/include/alpaca/detail/types/pair.h
@@ -44,8 +44,13 @@ bool from_bytes(std::pair<T, U> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   from_bytes_router<O>(output.first, bytes, byte_index, end_index, error_code);

--- a/include/alpaca/detail/types/set.h
+++ b/include/alpaca/detail/types/set.h
@@ -109,8 +109,13 @@ bool from_bytes(std::set<T> &output, Container &bytes, std::size_t &byte_index,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   from_bytes_to_set<O>(output, bytes, byte_index, end_index, error_code);
@@ -126,8 +131,13 @@ bool from_bytes(std::unordered_set<T> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   from_bytes_to_set<O>(output, bytes, byte_index, end_index, error_code);

--- a/include/alpaca/detail/types/string.h
+++ b/include/alpaca/detail/types/string.h
@@ -44,8 +44,13 @@ from_bytes(std::basic_string<CharType> &value, Container &bytes,
   value.clear();
   if (current_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the length of the string
@@ -84,8 +89,13 @@ from_bytes(std::basic_string<CharType> &value, Container &bytes,
   value.clear();
   if (current_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the length of the string

--- a/include/alpaca/detail/types/tuple.h
+++ b/include/alpaca/detail/types/tuple.h
@@ -90,8 +90,13 @@ bool from_bytes(std::tuple<T...> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   from_bytes_to_tuple<O>(output, bytes, byte_index, end_index, error_code);

--- a/include/alpaca/detail/types/unique_ptr.h
+++ b/include/alpaca/detail/types/unique_ptr.h
@@ -52,8 +52,13 @@ bool from_bytes(std::unique_ptr<T> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   auto current_byte = bytes[byte_index];

--- a/include/alpaca/detail/types/variant.h
+++ b/include/alpaca/detail/types/variant.h
@@ -60,8 +60,13 @@ bool from_bytes(std::variant<T...> &output, Container &bytes,
 
   if (byte_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the index of the variant value

--- a/include/alpaca/detail/types/vector.h
+++ b/include/alpaca/detail/types/vector.h
@@ -60,8 +60,13 @@ bool from_bytes_to_vector(std::vector<T> &value, Container &bytes,
 
   if (current_index >= end_index) {
     // end of input
-    // return true for forward compatibility
-    return true;
+    // return true for forward compatibility, unless strict mode is enabled
+    if constexpr (detail::strict<O>()) {
+      error_code = std::make_error_code(std::errc::bad_message);
+      return false;
+    } else {
+      return true;
+    }
   }
 
   // current byte is the size of the vector


### PR DESCRIPTION
We had a need to reject old versions of serialized data structures, and even turning on both `fixed_length_encoding` and `with_checksum` did not prevent older versions of the structures from deserializing as newer versions of the structures. This PR adds a new `strict` option, which properly disables that behavior. This allows us to have some nice fold semantics to handle what we want to do when we deserialize an older structure as a newer structure (ensuring properly defined movement / defaults). 

Manually handling versions:

```c++
template <alpaca::options O, typename CurrentVersionType, typename... OldVersionTypes>
class Storage {
    ...

    bool read() {
        if (!std::filesystem::exists(file_)) {
            logger_.warn("No file exists at '{}'", file_.string());
            return false;
        }

        // read the data from the file
        logger_.info("Reading file '{}'", file_.string());
        size_t file_size = std::filesystem::file_size(file_);
        std::ifstream ifs(file_, std::ios::in | std::ios::binary);
        ifs.seekg(0, std::ios::beg);
        std::vector<uint8_t> bytes;
        bytes.resize(file_size);
        ifs.read(reinterpret_cast<char *>(bytes.data()), file_size);
        ifs.close();
        logger_.debug("Read bytes: {::#02X}", bytes);

        // deserialize the data, trying each type in the list until one works
        std::optional<CurrentVersionType> maybe_new_data;
        bool did_deserialize = deserialize_type<CurrentVersionType>(bytes, maybe_new_data);
        if (!did_deserialize) {
            // use a fold expression (https://en.cppreference.com/w/cpp/language/fold) to
            // try each old version type in order
            did_deserialize = (deserialize_type<OldVersionTypes>(bytes, maybe_new_data) || ...);
        }

        if (did_deserialize) {
            data_ = maybe_new_data.value();
            logger_.info("Deserialized {} bytes from '{}'", file_size, file_.string());
            return true;
        } else {
            return false;
        }
    }


    template <typename U>
    bool deserialize_type(const std::vector<uint8_t> &bytes,
                          std::optional<CurrentVersionType> &new_data) {
        std::error_code ec;
        U test_data = bb::deserialize<O, U>(bytes, ec);
        if (!ec) {
            // NOTE: since alpaca requires aggregate types (no constructors), we
            //      can't use copy initialization / converting constructor here.
            //      Instead, we use default initialization and then use a
            //      converting assignment operator
            CurrentVersionType raw_data;
            // the next line requires that a conversion operator exists from U
            // to CurrentVersionType, such as:
            //   CurrentVersionType &operator=(const U &old_version_u) { ... }
            raw_data = std::move(test_data);
            // then we can set the optional value using the latest data
            new_data = raw_data;
            return true;
        } else {
            logger_.error(
                "Could not deserialize data from file '{}' - {}", file_.string(), ec.message());
            logger_.error("\traw bytes: {::#02X}", bytes);
            new_data = std::nullopt;
            return false;
        }
    }

    ...

};
```

Example code:

```c++
    // now test writing a version 1 to file and deserializing it as a version 2
    // (should fail)
    {
        logger.info("Running binary persistent data example with versioning!");
        //! [persistent data versioning example]
        // the filesystem must have been initialized
        auto &fs = espp::FileSystem::get();
        // where will we store the data?
        std::string filename = "version.pac";
        // now actually create it!
        bb::PersistentData<alpaca::options::fixed_length_encoding | alpaca::options::with_checksum | alpaca::options::strict, DeviceInfoDataV1> pd(
            {.file_path = fs.get_root_path() / filename,
             .log_level = espp::Logger::Verbosity::INFO});
        // get the data
        auto pd_data = pd.get();
        // modify the persistent data
        // now set the persistent data data back!
        pd.set(pd_data);
        bool success{false};
        logger.info("Writing version 1...");
        success = pd.write();
        if (!success) {
            logger.error("Failed!");
        }

        logger.info("Reading version 1 as version 2...");
        // now try to load that same file as a version 2
        bb::PersistentData<alpaca::options::fixed_length_encoding | alpaca::options::with_checksum | alpaca::options::strict, DeviceInfoDataV2> pd_v2(
            {.file_path = fs.get_root_path() / filename,
             .auto_load = false,
             .log_level = espp::Logger::Verbosity::INFO});
        success = pd_v2.read();
        if (success) {
            logger.error("Should have failed to read version 1 as version 2!");
        } else {
            logger.info("Success: properly failed to read version 1 as version 2!");
        }
        auto updated_pd_data = pd_v2.get();
    }
```

Before:
![CleanShot 2024-09-30 at 15 16 02](https://github.com/user-attachments/assets/5e7c60da-ec16-46aa-afbd-bf35ba341467)


After:
![CleanShot 2024-09-30 at 15 05 34](https://github.com/user-attachments/assets/2d6f9fcc-673b-4f3b-80c2-f2ca79804cf0)
